### PR TITLE
bug(requirements): remove bad dependecy in requirements.txt

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+certifi = "==2021.10.8"
+charset-normalizer = "==2.0.12"
+idna = "==3.3"
+requests = "==2.27.1"
+urllib3 = "==1.26.9"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,61 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "cea1cf4e1a27a695dff289aa4d67be79eda2caafa3266d14d04ca4b5c83c7737"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "index": "pypi",
+            "version": "==2021.10.8"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+            ],
+            "index": "pypi",
+            "version": "==2.0.12"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "index": "pypi",
+            "version": "==3.3"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+            ],
+            "index": "pypi",
+            "version": "==2.27.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
+                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+            ],
+            "index": "pypi",
+            "version": "==1.26.9"
+        }
+    },
+    "develop": {}
+}

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,5 +1,0 @@
-certifi==2021.10.8
-charset-normalizer==2.0.12
-idna==3.3
-requests==2.27.1
-urllib3==1.26.9

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -2,5 +2,4 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 idna==3.3
 requests==2.27.1
-sigma-dev-tools==0.1
 urllib3==1.26.9


### PR DESCRIPTION
This removes sigma-dev-tools from the dependency list, and adds Pipfile and Pipfile.env for use with pipenv