### PR TITLE
Gary/extend batch update users email

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,67 @@ This repository contains example scripts that use Sigma's public API. This is in
 
 See [the Developer Documentation](https://help.sigmacomputing.com/hc/en-us/sections/4408551771411-API-Get-Started) for more details on how to get started.
 
-## batch_update_users.py instructions
+## batch_update_users.py
 
+Batch update organization members' user attributes. The members' email addresses are used as identifiers for matching to their corresponding member IDs. 
+
+The script uses the `PATCH /v2/members/{memberId}` endpoint specified in our [API documentation here](https://help.sigmacomputing.com/hc/en-us/articles/4408555573267-Organization-Member-API#h_01FWMC0K925WE07AEYS1S65Q5M).
+
+You will need to have API credentials for a Sigma user account with Administrator privileges (Client Secret/Token and Client ID). See [our documentation here](https://help.sigmacomputing.com/hc/en-us/articles/4408555307027-Get-an-API-Token-and-Client-ID) for how to acquire those.
+
+### Instructions 
 Clone or download this repo for the script and its required Pipfile. The specific script is named `batch_update_users.py`
 
-> **Note**
-> You will need to have API credentials for a Sigma user account with Administrator privileges (Client Secret/Token and Client ID). See [our documentation here](https://help.sigmacomputing.com/hc/en-us/articles/4408555307027-Get-an-API-Token-and-Client-ID) for how to acquire those.
+#### Instructions for preparing the CSV file
 
-### Instructions for preparing the CSV file:
+Create a specifically-formatted CSV file for our script to be able to parse. The headers do not need to be ordered, but the script is case sensitive to their names.
+> See an example of this required format in the CSV file in this repo named: [example_csv_for_batch_update_users.csv](examples/example_csv_for_batch_update_users.csv)
 
-Create a specifically-formatted CSV file for our script to be able to parse the users' email addresses.
+**Required header:** Email
+**Optional headers:** First Name,Last Name,New Email,Member Type
 
-1.  Name the first column "Email" and list in the rows beneath it the current email addresses for the users whose addresses you want to change.
-2.  Name the second column "New Email" and list the corresponding new email addresses for each user.
-3.  Ensure there is no trailing whitespace at the end of any of the addresses and no other columns or unnecessary data in the file.
-    > See an example of this required format in the CSV file in this repo named: [example_csv_for_batch_update_users.csv](examples/example_csv_for_batch_update_users.csv)
+The values for the "Email" column will be the email addresses of the users whose attributes you want to update.
 
-### Instructions for preparing the runtime environment and executing the script:
+You are free to include or exclude any of the optional columns depending on which user attributes you want to update.
 
-1.  Install pipenv in your local system. (Install instructions are [here](http://pipenv.pypa.io/))
-2.  Navigate into the folder where the `batch_update_users.py` script is, and open up a command line terminal from there.
-3.  Run: `pipenv install`
-    > **Note**
-    > The Pipfile in this Github repo must be present in the same folder when doing this as it contains the dependencies pipenv needs to be able to install the runtime environment.
-4.  Replace the <> fields in the below template command with the relevant values for their corresponding options and run it:
+For example, if you only want to update users' email addresses, your headers would be: `Email,New Email`
+
+If you wanted to update a mixture of attributes for some users but not others, then leave the values you don't want updated blank for those users. 
+
+Ensure there is no trailing whitespace at the end of any of the addresses and no other columns or unnecessary data in the file.
+
+#### Instructions for preparing the runtime environment
+
+1. Install Python3. [Instructions here](https://www.python.org/downloads/).
+2.  Install pipenv. [Instructions here](http://pipenv.pypa.io/)
+3.  In a command line terminal, navigate into the folder where the `batch_update_users.py` script is and run: `pipenv install` 
+    > The Pipfile in this Github repo must be present in the same folder when running this command. It contains information about the dependencies pipenv needs to install inside the virtual environment for the script to use. You will see that a file called "Pipfile.lock" gets created when doing this.
+    
+#### Instructions for executing the script
+
+Replace the `<>` fields in the below template command with the relevant values for their corresponding arguments:
 
 `pipenv run python batch_update_users.py --client_id <client_id> --client_secret <client_secret> --csv <path_to_your_csv_file> --env production --cloud <aws | gcp>`
 
-> **Note**
-> You will select either "aws" or "gcp" for the "--cloud" option depending on which instance your Sigma is running.
+|Argument|Description|Required?
+|--|--|--|
+| **client_id** | Client ID generated from within Sigma |Yes
+| **client_secret** | Client Secret (API token) generated from within Sigma |Yes
+| **csv** | Path to CSV file |Yes
+| **env** | Environment to use: production or staging. You should use production |Yes
+| **cloud** | Cloud provider your Sigma instance is on: aws or gcp |Yes
+| **abort_on_update_fail** | Script should abort on any update error: enable |No
+
+> You will select either "aws" or "gcp" for the " --cloud" option depending on which provider your Sigma instance is running on. You can see which cloud yours is inside Sigma by going to Administration->Account->General Settings. (We need to know this because there are [separate APIs for each](https://help.sigmacomputing.com/hc/en-us/articles/4408835546003-Get-Started-with-Sigma-s-API#ite))
 
 Example run command:
 
 `pipenv run python batch_update_users.py --client_id 123 --client_secret abc --csv ./update_emails.csv --env production --cloud gcp`
+
+> By default, when the script encounters an error attempting to update a particular member's metadata, it will print the error and move on to try update the next member listed in the CSV. 
+>
+>If you want to abort the script when it encounters any such error, you can include the optional argument: `--abort_on_update_fail enable`
+
+Example run command with optional argument to abort on any update error:
+
+`pipenv run python batch_update_users.py --client_id 123 --client_secret abc --csv ./update_emails.csv --env production --cloud gcp --abort_on_update_fail enable`

--- a/batch_update_users.py
+++ b/batch_update_users.py
@@ -33,7 +33,7 @@ def get_access_token(url, client_id, client_secret):
         "client_secret": client_secret
     }
     response = requests.post(f"{url}/v2/auth/token", data=payload)
-    print(response)
+    print(f"Get Access Token response: {response}")
     data = response.json()
 
     return data["access_token"]

--- a/batch_update_users.py
+++ b/batch_update_users.py
@@ -126,7 +126,7 @@ def main():
     parser.add_argument(
         '--csv', type=str, required=True, help='CSV file containing members\' current email addresses and metadata to be updated. Column names are case sensitive. Required column: Email, Optional columns: First Name,Last Name,New Email,Member Type')
     parser.add_argument(
-        '--cloud', type=str, required=True, help='cloud to use: [aws | gcp] (if unsure which cloud provider your organization is hosted on, check in the Account section in Administration)'
+        '--cloud', type=str, required=True, help='cloud to use: [aws | gcp] (if unsure which, in Sigma go to Administration->Account->General Settings)'
     )
     parser.add_argument(
         '--abort_on_update_fail', type=str, required=False, help='should script abort and not try to update the next member when an attempted update fails for the current member? [enable]'

--- a/batch_update_users.py
+++ b/batch_update_users.py
@@ -117,14 +117,14 @@ def get_all_members(url, access_token):
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Batch update organization members\' metadata using members\' email addresses as identifiers')
+        description='Batch update organization members\' user attributes using members\' email addresses as identifiers')
 
     parser.add_argument(
         '--client_id', type=str, required=True, help='Client ID generated from within Sigma')
     parser.add_argument(
         '--client_secret', type=str, required=True, help='Client secret API token generated from within Sigma')
     parser.add_argument(
-        '--csv', type=str, required=True, help='CSV file containing members\' current email addresses and metadata to be updated. Column names are case sensitive. Required column: Email, Optional columns: First Name,Last Name,New Email,Member Type')
+        '--csv', type=str, required=True, help='CSV file containing members\' email addresses and their user attributes to be updated. Column names are case sensitive. Required column: Email, Optional columns: First Name,Last Name,New Email,Member Type')
     parser.add_argument(
         '--cloud', type=str, required=True, help='cloud to use: [aws | gcp] (if unsure which, in Sigma go to Administration->Account->General Settings)'
     )
@@ -210,7 +210,7 @@ def main():
         except KeyError:
             print(f"\u2717 UPDATE FAILURE!")
             print(f"Member email: {member_email}")
-            print(f"This email address is either invalid, or is not found, or is for a deactivated account (reactivate the account first to change its metadata)")
+            print(f"This email address is either invalid, or is not found, or is for a deactivated account (reactivate the account first to change its user attributes)")
             print(f"###")
             if args.abort_on_update_fail == "enable":
                 raise SystemExit("Script aborted")
@@ -243,7 +243,7 @@ def main():
                 if member_first_name is None and member_last_name is None and member_new_email is None and member_type is None:
                     print(f"\u2013 UPDATED NOTHING!")
                     print(f"Member email: {member_email}")
-                    print(f"There was no metadata included in the CSV for this member")
+                    print(f"There were no user attribute values included in the CSV for this member")
                     print(f"###")
                 else:
                     print(f"\u2713 UPDATE SUCCESS!")

--- a/batch_update_users.py
+++ b/batch_update_users.py
@@ -92,6 +92,10 @@ def main():
     parser.add_argument(
         '--cloud', type=str, required=True, help='cloud to use: [aws | gcp].'
     )
+        parser.add_argument(
+        '--skip_invalid_emails', type=str, required=False, help='should invalid emails be skipped: [yes]'
+    )
+
     args = parser.parse_args()
     url = get_baseurl(args.env, args.cloud)
     access_token = get_access_token(url, args.client_id, args.client_secret)

--- a/batch_update_users.py
+++ b/batch_update_users.py
@@ -32,12 +32,25 @@ def get_access_token(url, client_id, client_secret):
         "client_id": client_id,
         "client_secret": client_secret
     }
-    response = requests.post(f"{url}/v2/auth/token", data=payload)
-    print(f"Get Access Token response: {response}")
-    data = response.json()
+    
+    try:
+        print(f"Fetching Access Token...")
+        response = requests.post(f"{url}/v2/auth/token", data=payload)
+        response.raise_for_status()
+ 
+    except requests.exceptions.HTTPError as errh:
+        raise Exception(f"Connection Error: {errh}, API response: {errh.response.text}")
+    except requests.exceptions.ConnectionError as errc:
+        raise Exception(f"Connection Error: {errc}, API response: {errc.response.text}")
+    except requests.exceptions.Timeout as errt:
+        raise Exception(f"Timeout Error: {errh}, API response: {errt.response.text}")
+    except requests.exceptions.RequestException as err:
+        raise Exception(f"Other Error: {err}, API response: {err.response.text}")
+    else:
+        print(f"...Success!")
+        data = response.json()
 
-    return data["access_token"]
-
+        return data["access_token"]
 
 def get_headers(access_token):
     """ Gets headers for API requests
@@ -48,8 +61,6 @@ def get_headers(access_token):
     """
     return {"Authorization": "Bearer " + access_token}
 
-
-
 def update_member(url, access_token, user_id, payload):
     """ Update member
 
@@ -57,114 +68,195 @@ def update_member(url, access_token, user_id, payload):
         :userId:        ID of the user to update
         :payload:       Fields to update
 
-        :returns:       Member ID
+        :returns:       Response JSON
 
     """
-    response = requests.patch(
-        f"{url}/v2/members/{user_id}",
-        headers=get_headers(access_token),
-        json=payload
-    )
-    data = response.json()
-    return data["memberId"]
+    try:
+        response = requests.patch(
+            f"{url}/v2/members/{user_id}",
+            headers=get_headers(access_token),
+            json=payload
+        )
+        response.raise_for_status()
+    # HTTP and other errors are handled generally by raising them as exceptions to be surfaced in downstream code
+    except requests.exceptions.HTTPError as errh:
+        # The API response's message value is sent in lieu of the full response to display to the user for clarity
+        # Certain error response messages are useful for the user troubleshoot common issues, such as invalid Member Type or New Email already in use
+        raise Exception(errh.response.status_code, f"API message: {errh.response.json()['message']}")
+    except requests.exceptions.ConnectionError as errc:
+        raise Exception(f"Connection Error: {errc}, API response: {errc.response.text}")
+    except requests.exceptions.Timeout as errt:
+        raise Exception(f"Timeout Error: {errh}, API response: {errt.response.text}")
+    except requests.exceptions.RequestException as err:
+        raise Exception(f"Other Error: {err}, API response: {err.response.text}")
+    else:
+        data = response.json()
+
+        return data
 
 def get_all_members(url, access_token):
-    response = requests.get(
-        f'{url}/v2/members',
-        headers=get_headers(access_token)
-    )
-    res = response.json()
-    return res
+    try:
+        response = requests.get(
+            f'{url}/v2/members',
+            headers=get_headers(access_token)
+        )
+        response.raise_for_status()
+ 
+    except requests.exceptions.HTTPError as errh:
+        raise Exception(f"Connection Error: {errh}, API response: {errh.response.text}")
+    except requests.exceptions.ConnectionError as errc:
+        raise Exception(f"Connection Error: {errc}, API response: {errc.response.text}")
+    except requests.exceptions.Timeout as errt:
+        raise Exception(f"Timeout Error: {errh}, API response: {errt.response.text}")
+    except requests.exceptions.RequestException as err:
+        raise Exception(f"Other Error: {err}, API response: {err.response.text}")
+    else:
+        data = response.json()
+
+        return data
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Batch update organization member by email')
+        description='Batch update organization members\' metadata using members\' email addresses as identifiers')
 
     parser.add_argument(
-        '--client_id', type=str, required=True, help='Client ID generated from Sigma')
+        '--client_id', type=str, required=True, help='Client ID generated from within Sigma')
     parser.add_argument(
-        '--client_secret', type=str, required=True, help='Client secret generated from Sigma')
+        '--client_secret', type=str, required=True, help='Client secret API token generated from within Sigma')
     parser.add_argument(
-        '--csv', type=str, required=True, help='CSV file containing all the data, format expected: Email,First Name,Last Name,New Email')
+        '--csv', type=str, required=True, help='CSV file containing members\' current email addresses and metadata to be updated. Column names are case sensitive. Required column: Email, Optional columns: First Name,Last Name,New Email,Member Type')
     parser.add_argument(
-        '--env', type=str, required=True, help='env to use: [production | staging].'
+        '--cloud', type=str, required=True, help='cloud to use: [aws | gcp] (if unsure which cloud provider your organization is hosted on, check in the Account section in Administration)'
     )
     parser.add_argument(
-        '--cloud', type=str, required=True, help='cloud to use: [aws | gcp].'
+        '--abort_on_update_fail', type=str, required=False, help='should script abort and not try to update the next member when an attempted update fails for the current member? [enable]'
     )
     parser.add_argument(
-        '--skip_invalid_emails', type=str, required=False, help='should invalid emails be skipped: [yes]'
+        '--env', type=str, required=True, help='env to use: [production | staging] (external users should always use production)'
     )
 
     args = parser.parse_args()
     url = get_baseurl(args.env, args.cloud)
-    access_token = get_access_token(url, args.client_id, args.client_secret)
-    # parse csv
+
+    try:
+        access_token = get_access_token(url, args.client_id, args.client_secret)
+    except Exception as e:
+        print(f"{e}")
+        raise SystemExit("Script aborted")
+
+    # Get all members for the organization and make a dict of their emails and memberIds
+    try:
+        members = get_all_members(url, access_token)
+    except Exception as e:
+        print(f"{e}")
+        raise SystemExit("Script aborted")
+    members_dict = {}
+    for m in members:
+     members_dict[m['email']] = m['memberId']
+
+    # Parse csv
     updated_members = []
     with open(args.csv) as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             updated_members.append(row)
-
-    # Get all members for the organization
-    members = get_all_members(url, access_token)
-
-    members_dict = {}
-    for m in members:
-     members_dict[m['email']] = m['memberId']
-
-    # when user enables skip_invalid_emails arg: script will bypass KeyErrors and try the next member_email in the updated_members list
-    if args.skip_invalid_emails == "yes":
-
-        for m in updated_members:
-            member_email = m['Email']
-            try:
-                member_id = members_dict[member_email]
-            except KeyError:
-                print(f"\u2717 FAILURE! Did not update {member_email}: address not found or is for a deactivated account")
+    
+    for m in updated_members:
+        try:
+            if len(m['Email']) > 1:
+                member_email = m['Email']
             else:
-                payload = {}
-                for k, v in m.items():
-                    if k == 'First Name':
-                        payload['firstName'] = v
-                    if k == 'Last Name':
-                        payload['lastName'] = v
-                    if k == 'New Email':
-                        payload['email'] = v
-                try:
-                    update_member(url, access_token, member_id, payload)
-                except KeyError:
-                    print(f"\u2717 FAILURE! Did not update {member_email}: {payload['email']} already in use")
-                else:
-                    print(f"\u2713 SUCCESS! {member_email} updated to {payload['email']}")
+                member_email = None
+        except KeyError:
+            print(f"\u2717 CSV FILE ERROR!")
+            print(f"A column titled \"Email\" is a required column in the CSV for this script to be able to run")
+            print(f"###")
+            raise SystemExit("Script aborted")
 
-    # when user does not enable skip_invalid_emails arg: default script behavior when encountering KeyError is to abort (exit code 1)
-    else:
+        # This block of try/excepts sets the variables that get used as the request payload's values for the optional columns 
+        # They will be set to None if the column itself is absent or if its value is blank/empty
+        # These KeyErrors do not apply to the --abort_on_update_flag option
+        try:
+            if len(m['First Name']) > 1:
+                member_first_name = m['First Name']
+            else:
+                member_first_name = None
+        except KeyError:
+                member_first_name = None
+        try:
+            if len(m['Last Name']) > 1:
+                member_last_name = m['Last Name']
+            else:
+                member_last_name = None
+        except KeyError:
+                member_last_name = None
+        try:
+            if len(m['New Email']) > 1:
+                member_new_email = m['New Email']
+            else:
+                member_new_email = None
+        except KeyError:
+                member_new_email = None
+        try:
+            if len(m['Member Type']) > 1:
+                member_type = m['Member Type']
+            else:
+                member_type = None
+        except KeyError:
+                member_type = None
 
-        for m in updated_members:
-            member_email = m['Email']
-            try:
-                member_id = members_dict[member_email]
-            except KeyError:
-                print(f"\u2717 FAILURE! Did not update {member_email}: address not found or is for a deactivated account")
+        try:
+            member_id = members_dict[member_email]
+        except KeyError:
+            print(f"\u2717 UPDATE FAILURE!")
+            print(f"Member email: {member_email}")
+            print(f"This email address is either invalid, or is not found, or is for a deactivated account (reactivate the account first to change its metadata)")
+            print(f"###")
+            if args.abort_on_update_fail == "enable":
                 raise SystemExit("Script aborted")
-            else:
-                payload = {}
-                for k, v in m.items():
-                    if k == 'First Name':
-                        payload['firstName'] = v
-                    if k == 'Last Name':
-                        payload['lastName'] = v
-                    if k == 'New Email':
-                        payload['email'] = v
-                try:
-                    update_member(url, access_token, member_id, payload)
-                except KeyError:
-                    print(f"\u2717 FAILURE! Did not update {member_email}: {payload['email']} already in use")
-                    raise SystemExit("Script aborted")
-                else:
-                    print(f"\u2713 SUCCESS! {member_email} updated to {payload['email']}")
+        else:
+            payload = {}
+            if member_first_name:
+                    payload['firstName'] = member_first_name
+            if member_last_name:
+                    payload['lastName'] = member_last_name
+            if member_new_email:
+                    payload['email'] = member_new_email
+            if member_type:
+                payload['memberType'] = member_type
 
+            try:
+                update_member_response = update_member(url, access_token, member_id, payload)
+            except Exception as e:
+                print(f"\u2717 UPDATE FAILURE!")
+                print(f"Member email: {member_email}")
+                print(f"The below API error prevented an update being applied for this member:")
+                print(f"{e}")
+                if e.args[0] == 404:
+                    print(f"If the 404 error message is \"Member type name is not found\", the Member Type specified is invalid/not in use: {payload['memberType']}")
+                if e.args[0] == 409:
+                    print(f"If the 409 error message is \"Duplicate record\", the New Email specified is in use by an existing member: {payload['email']}")
+                print(f"###")
+                if args.abort_on_update_fail == "enable":
+                    raise SystemExit("Script aborted")
+            else:
+                if member_first_name is None and member_last_name is None and member_new_email is None and member_type is None:
+                    print(f"\u2013 UPDATED NOTHING!")
+                    print(f"Member email: {member_email}")
+                    print(f"There was no metadata included in the CSV for this member")
+                    print(f"###")
+                else:
+                    print(f"\u2713 UPDATE SUCCESS!")
+                    print(f"Member email: {member_email}")
+                    if member_first_name:
+                        print(f"First Name updated to: {update_member_response['firstName']}")
+                    if member_last_name:
+                        print(f"Last Name updated to: {update_member_response['lastName']}")
+                    if member_new_email:
+                        print(f"Email updated to: {update_member_response['email']}")
+                    if member_type:
+                        print(f"Member type updated to: {update_member_response['memberType']}")
+                    print(f"###")
 
 if __name__ == '__main__':
     main()

--- a/examples/example_csv_for_batch_update_users.csv
+++ b/examples/example_csv_for_batch_update_users.csv
@@ -1,3 +1,4 @@
-Email,New Email
-anne@oldemail.com,anne@newemail.com
-bob@oldemail.com,bob@newemail.com
+Email,First Name,Last Name,New Email,Member Type
+gareth@sigmacomputing.com,Gary,Brick,,
+brett@sigmacomputing.com,,,,Creator
+jacob@sigma.com,,,jacob@sigmacomputing.com,


### PR DESCRIPTION

There are two distinct KeyError cases that needed to be handled. The first arises when an old email address is not found or is for a deactivated account. The second arises when a desired new email address is already in use.

The script will have an optional command line argument called "--skip_invalid_emails" that can enable the feature to bypass these KeyErrors and continue looping through the list of member_emails to update.

In order to accommodate the "skip_invalid_emails" feature and to upgrade the default behavior, I inserted try/except blocks so that aborting or continuing the script could be controlled at the points at which the two cases of KeyError could occur. As a side-effect of this, each attempted email update will be POSTed individually rather than combined into a single payload. As a result of this, I could also improve the script's logging so that each update attempt for each email will have its success/fail outcome explicitly printed to the terminal with a reason stated for why if it failed.

Lastly, I improved the default behavior so that when KeyError is excepted the script will abort gracefully with exit code 1.